### PR TITLE
Ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: python --version
       - run:
           name: Equip machine with wmctrl, a vital dependency of pydoer
-          command: sudo apt-get install -y wmctrl
+          command: sudo apt-get update && sudo apt-get install -y wmctrl
       - run:
           name: Equip machine with latest pip & wheel
           command: python -m pip install -U pip wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ executors:
   java15-docker-image:
     docker:
       - image: cimg/openjdk:15.0.1
+  base-linux-2021_07:
+    docker:
+    - image: cimg/base:2021.07
   ubuntu-1604-vm:
     machine:
       image: ubuntu-1604:201903-01
@@ -79,7 +82,7 @@ jobs:
             java -jar codacy-coverage-reporter-assembly.jar report -l Python -r coverage.xml
 
   send-coverage-to-codecov:
-    executor: ubuntu-1604-vm
+    executor: base-linux-2021_07
     steps:
       - attach_workspace:
           at: .
@@ -176,6 +179,12 @@ workflows:
                 - master
                 - dev
                 - release-staging
+      - deploy-to-staging:
+          requires:
+            - build_n_test
+          filters:
+            branches:
+              only: release-staging
       # - build-documentation:
       #     filters:
       #       branches:
@@ -183,15 +192,3 @@ workflows:
       #           - master
       #           - dev
       #           - release-staging
-      - deploy-to-staging:
-          requires:
-            - build_n_test
-          filters:
-            branches:
-              only: release-staging
-      # - integration-test:
-      #     requires:
-      #       - deploy-to-staging
-      #     filters:
-      #       branches:
-      #         only: release-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: circleci/python:3.7.9
   py38-docker-image:
     docker:
-      - image: circleci/python:3.8.9
+      - image: cimg/python:3.8.12
   java15-docker-image:
     docker:
       - image: cimg/openjdk:15.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
       PYDOER_DEPS_GRAPHS: dependencies-graphs
     steps:
       - checkout
-      - run: sudo apt-get --allow-releaseinfo-change update
+      - run: sudo apt-get update
       - run: python -m pip install -U pip
       - run:
           name: Install the dot binary included in the graphviz package/distribution

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2.1
 
 executors:
-  py37-docker-image:
-    docker:
-      - image: circleci/python:3.7.9
   py38-docker-image:
     docker:
       - image: cimg/python:3.8.12
@@ -13,9 +10,7 @@ executors:
   base-linux-2021_07:
     docker:
     - image: cimg/base:2021.07
-  ubuntu-1604-vm:
-    machine:
-      image: ubuntu-1604:201903-01
+
 
 jobs:
   build_n_test:

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,44 @@ PYDOER - CLI Application
 PyDoer is a CLI application aiming to automate executing multiple commands in different
 terminal applications.
 
+.. start-badges
+
+| |circleci| |codecov|
+| |better_code_hub| |codacy| |maintainability| |codeclimate_tech_debt| |sc1|
+
+|
+| **Source Code:** https://github.com/boromir674/doer
+|
+
+.. |circleci| image:: https://circleci.com/gh/boromir674/doer/tree/dev.svg?style=shield
+    :alt: CircleCI
+    :target: https://circleci.com/gh/boromir674/doer/tree/dev
+
+.. |codecov| image:: https://img.shields.io/codecov/c/github/boromir674/doer/dev?logo=codecov
+    :alt: Codecov
+    :target: https://codecov.io/gh/boromir674/doer
+
+
+.. |better_code_hub| image:: https://bettercodehub.com/edge/badge/boromir674/doer?branch=dev
+    :alt: Better Code Hub
+    :target: https://bettercodehub.com/
+
+.. |codacy| image:: https://app.codacy.com/project/badge/Grade/95d0b7816b9d4f17a986a877cc16c64a
+    :alt: Codacy
+    :target: https://www.codacy.com/gh/boromir674/doer/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=boromir674/doer&amp;utm_campaign=Badge_Grade
+
+.. |maintainability| image:: https://api.codeclimate.com/v1/badges/b5bdd6ec9c1dad2fe2d0/maintainability
+    :alt: Maintainability
+    :target: https://codeclimate.com/github/boromir674/doer/maintainability
+
+.. |codeclimate_tech_debt| image:: https://img.shields.io/codeclimate/tech-debt/boromir674/doer?logo=code%20climate
+    :alt: Code Climate technical debt
+    :target: https://codeclimate.com/github/boromir674/doer/trends/technical_debt
+
+.. |sc1| image:: https://img.shields.io/scrutinizer/quality/g/boromir674/doer/dev?logo=scrutinizer&style=flat
+    :alt: Scrutinizer code quality
+    :target: https://scrutinizer-ci.com/g/boromir674/doer/?branch=dev
+
 
 
 Featuring


### PR DESCRIPTION
Setup Continuous Integration

To facilitate CI tasks, such as running the test suite, measuring code coverage, code auditing we use several external web services that "host" such operations.

CI operations:

- Run test suite against each commit: CircleCI
- Automatically, create a visual graph representing the code module inter-dependencies and host online.
Eg: if you wrote a single script a.py that has one import statement "import numpy" then the graph would look like [numpy] ----> [a.py]. The job is hosted in CircleCI and triggers only on branches master, dev and release-staging
- Automatically deploy the python package into a "staging server".
It is very common, before "deploying into production", to "deploy into staging" to facilitate various testing operations (eg stress testing, e2e testing, integration testing). A "staging server" should be as identical to the target "production server" as possible.
Since, we are in the python ecosystem we consider staging to be testpypi.org and production to be pypi.org.
- Measure code coverage and host results and stats : codecov
- Measure a metric of the "code maintainability" : codeclimate
- Measure a metric of the "code technical debt" : codeclimate
- Measure a metric of "code quality" (docs, lint, style, dead code, etc)": codacy
- Measure a metric of "code quality" (complexity, )": scrutinizer

Request the status of the CI operations from the above web services  (circleci, codecov, etc) and render them as code badges in README.
Each badge is clickable and redirects to the respective external ci service.